### PR TITLE
MAINT: Add dependabot yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - "github-actions"
+      - "dependabot"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,6 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci
+      - meeseeksmachine

--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ The drawback is if there is a security issue, then we're screwed.
 
 1. Enjoy
 
-Beta Phase: During Beta phase repository/users need to be vetted/allowlisted
-open an issue if you wish to participate.
-
 You might also want to tell your CI-integration (like travis-ci) **not** to test the **push** __and__ **the merge**.
 To do so use:
 


### PR DESCRIPTION
Closes #127

@Carreau I think this should already be enough to get dependabot to open PRs. At least for other projects in orgs without Dependabot added I think it has made it start opening PRs.

Also removes some cruft from the README and adds a `release.yml` in case we want to use autogenerated release notes at some point.